### PR TITLE
remove active class from filter button when new run

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -79,6 +79,9 @@ class Main {
                 //Clean up elements to append data to.
                 render.cleanDataWrapper(selection.important_buildtypes)
 
+                //Reset activate class on filters, because new run won't filter directly
+                render.resetFilterToggle()
+
                 //Add the include projects wrapper elements
                 render.addParentProjectElements(selection.include_projects)
 

--- a/src/render.js
+++ b/src/render.js
@@ -222,4 +222,11 @@ class HtmlRender {
             document.body.classList.add('loading')
         }
     }
+
+    resetFilterToggle() {
+        let unchangedToggle = document.getElementById('toggle_unchanged')
+        let greenToggle = document.getElementById('toggle_green')
+        unchangedToggle.classList.remove('active')
+        greenToggle.classList.remove('active')
+    }
 }


### PR DESCRIPTION
When a new selection is applied and the buildtypes and projects are reloaded the filter buttons now reset their active state.